### PR TITLE
[GH-50] Pandas 1.0 compatible issue. (#51)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: python
 dist: xenial
 python:
     - "2.7"
-    - "3.4"
     - "3.5"
     - "3.6"
     - "3.7"
+    - "3.8"
 install:
     - sudo apt-get install python-numpy
     - sudo apt-get install python-pandas

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Stock Statistics/Indicators Calculation Helper
     :target: https://pypi.python.org/pypi/stockstats
 
 
-VERSION: 0.3.0
+VERSION: 0.3.1
 
 Introduction
 ------------
@@ -62,6 +62,13 @@ Installation
 
 ``pip install stockstats``
 
+Compatibility
+-------------
+
+Please check the `setup.py`_ file.
+
+Note that pandas add some type check after version 1.0.
+One type assert is skipped in ``StockDataFrame``.  Check ISSUE-50 for detail.
 
 License
 -------
@@ -260,3 +267,4 @@ Contact author:
 - Cedric Zhuang <jealous@163.com>
 
 .. _BSD: LICENSE.txt
+.. _setup.py: setup.py

--- a/setup.py
+++ b/setup.py
@@ -80,9 +80,10 @@ setup(
     classifiers=[
         "Programming Language :: Python",
         "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: Implementation :: CPython",
         "Natural Language :: English",
         "Intended Audience :: Developers",

--- a/stockstats.py
+++ b/stockstats.py
@@ -350,6 +350,13 @@ class StockDataFrame(pd.DataFrame):
     def _drop_columns(df, columns):
         df.drop(columns, inplace=True, axis=1)
 
+    def _ensure_type(self, obj):
+        """ override the method in pandas, omit the check
+
+        This patch is not the perfect way but could make the lib work.
+        """
+        return obj
+
     @classmethod
     def _get_smma(cls, df, column, windows):
         """ get smoothed moving average.


### PR DESCRIPTION
Pandas 1.0 introduces a `_ensure_type` method that asserts the type of
`self` must be the same type as the input `obj`.  In this lib, the type
of `self` is `StockDataFrame` and the type of the object is `DataFrame`
which breaks this assert.

The temporary fix is to bypass the assert by override the `_ensure_type`
method in `StockDataFrame`.  The is just a work around.  The good news
is that the original method doesn't contain any business logic.

Other changes:
* Update the travis configuration to add CI for python 3.8.
* Drop the CI build for 3.4.  It's too old and takes too long to run.